### PR TITLE
access full transaction directly from event origin; cleanup

### DIFF
--- a/Allo/spec.ts
+++ b/Allo/spec.ts
@@ -54,7 +54,7 @@ class Allo extends LiveObject {
         this.treasury = event.data.treasury;
     }
 
-        @OnEvent("allov2.Allo.StrategyApproved")
+    @OnEvent("allov2.Allo.StrategyApproved")
     async onStrategyApproved(event: Event) {
         await this.load();
 

--- a/Profile/spec.ts
+++ b/Profile/spec.ts
@@ -54,7 +54,7 @@ class Profile extends LiveObject {
     }
 
     @OnEvent("allov2.Registry.ProfileCreated")
-    async onProfileCreated(event: Event) {
+    onProfileCreated(event: Event) {
         this.profileId = event.data.profileId
         this.nonce = BigInt.from(event.data.nonce)
         this.name = event.data.name
@@ -65,9 +65,7 @@ class Profile extends LiveObject {
 
         this.owner = event.data.owner
         this.anchor = event.data.anchor
-
-        const tx = await this.getCurrentTransaction()
-        this.creator = tx.from
+        this.creator = this.currentTransaction.from
 
         this.createdAt = this.blockTimestamp
     }

--- a/imports.json
+++ b/imports.json
@@ -1,5 +1,5 @@
 {
     "imports": {
-        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.120"
+        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.122"
     }
 }


### PR DESCRIPTION
Bumps spec core version, allowing access to the full event transaction object directly from either:
- `this.currentTransaction`
- `event.origin.transaction`