### PR TITLE
Cleaner property defaults

### DIFF
--- a/Allo/spec.ts
+++ b/Allo/spec.ts
@@ -18,10 +18,10 @@ class Allo extends LiveObject {
     @Property()
     registry: Address;
 
-    @Property({ default: 0 })
+    @Property()
     feePercentage: BigInt;
 
-    @Property({ default: 0 })
+    @Property()
     baseFee: BigInt;
 
     @Property()
@@ -57,16 +57,12 @@ class Allo extends LiveObject {
     @OnEvent("allov2.Allo.StrategyApproved")
     async onStrategyApproved(event: Event) {
         await this.load();
-
-        this.cloneableStrategies = this.cloneableStrategies || []
         this.cloneableStrategies.push(event.data.strategy);
     }
 
     @OnEvent("allov2.Allo.StrategyRemoved")
     async onStrategyRemoved(event: Event) {
         await this.load();
-
-        this.cloneableStrategies = this.cloneableStrategies || []
         this.cloneableStrategies = this.cloneableStrategies.filter(
             (strategy) => strategy !== event.data.strategy
         );

--- a/Pool/spec.ts
+++ b/Pool/spec.ts
@@ -42,13 +42,13 @@ class Pool extends LiveObject {
     @Property()
     tokenMetadata: Json;
 
-    @Property({ default: 0 })
+    @Property()
     amount: BigInt;
 
-    @Property({ default: 0 })
+    @Property()
     feePaid: BigInt;
 
-    @Property({ default: 0 })
+    @Property()
     baseFeePaid: BigInt;
 
     @Property()
@@ -112,14 +112,14 @@ class Pool extends LiveObject {
     @OnEvent("allov2.Allo.PoolFunded")
     async onPoolFunded(event: Event) {
         await this.load();
-        this.amount = BigInt.from(this.amount || 0).plus(event.data.amount);
-        this.feePaid = BigInt.from(this.feePaid || 0).plus(event.data.fee);
+        this.amount = this.amount.plus(event.data.amount);
+        this.feePaid = this.feePaid.plus(event.data.fee);
     }
 
     @OnEvent("allov2.Allo.BaseFeePaid")
     async onBaseFeePaid(event: Event) {
         await this.load();
-        this.baseFeePaid = BigInt.from(this.baseFeePaid || 0).plus(event.data.amount);
+        this.baseFeePaid = this.baseFeePaid.plus(event.data.amount);
     }
 }
 

--- a/Profile/spec.ts
+++ b/Profile/spec.ts
@@ -20,7 +20,7 @@ class Profile extends LiveObject {
     @Property()
     profileId: Address;
 
-    @Property({ default: 0 })
+    @Property()
     nonce: BigInt;
 
     @Property()
@@ -55,7 +55,6 @@ class Profile extends LiveObject {
 
     @OnEvent("allov2.Registry.ProfileCreated")
     onProfileCreated(event: Event) {
-        this.profileId = event.data.profileId
         this.nonce = BigInt.from(event.data.nonce)
         this.name = event.data.name
 
@@ -86,7 +85,6 @@ class Profile extends LiveObject {
     onProfileOwnerUpdated(event: Event) {
         this.owner = event.data.owner
     }
-
 }
 
 export default Profile;

--- a/imports.json
+++ b/imports.json
@@ -1,5 +1,5 @@
 {
     "imports": {
-        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.123"
+        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.129"
     }
 }

--- a/strategies/RFPStrategy/Base/spec.ts
+++ b/strategies/RFPStrategy/Base/spec.ts
@@ -23,7 +23,7 @@ class RFP extends LiveObject {
     @Property({ default: false })
     active: boolean
 
-    @Property({ default: 0 })
+    @Property()
     maxBid: BigInt
 
     @Property()

--- a/strategies/RFPStrategy/Recipient/spec.ts
+++ b/strategies/RFPStrategy/Recipient/spec.ts
@@ -19,7 +19,7 @@ class RFPRecipient extends LiveObject {
     @Property()
     poolId: string
 
-    @Property({ default: 0 })
+    @Property()
     proposalBid: BigInt
 
     @Property()


### PR DESCRIPTION
* Bumps `@spec.dev/core` to the latest version
* Gives all numeric types a default of `0` 
* Gives all array types a default of `[]`
* Requires CLI version `>= 0.2.1` (`npm i -g @spec.dev/cli` to upgrade)