### PR TITLE
Micro tweaks

### DIFF
--- a/Account/spec.ts
+++ b/Account/spec.ts
@@ -1,4 +1,4 @@
-import { Address, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 /**
  * All accounts on Allo V2.
@@ -6,7 +6,7 @@ import { Address, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/c
 @Spec({
     uniqueBy: ['accountId', 'chainId']
 })
-class Account extends LiveObject {
+class Account extends LiveTable {
 
     @Property()
     accountId: Address

--- a/Allo/spec.ts
+++ b/Allo/spec.ts
@@ -2,7 +2,7 @@ import {
     Address,
     BigInt,
     Event,
-    LiveObject,
+    LiveTable,
     OnEvent,
     Property,
     Spec,
@@ -14,7 +14,7 @@ import {
 @Spec({
     uniqueBy: ["chainId"],
 })
-class Allo extends LiveObject {
+class Allo extends LiveTable {
     @Property()
     registry: Address;
 

--- a/Pool/spec.ts
+++ b/Pool/spec.ts
@@ -5,7 +5,7 @@ import {
     Event,
     getERC20TokenMetadata,
     Json,
-    LiveObject,
+    LiveTable,
     OnEvent,
     Property,
     Spec,
@@ -21,7 +21,7 @@ import { generatePoolRoleIds } from "../shared/roles.ts";
 @Spec({
     uniqueBy: ["poolId", "chainId"],
 })
-class Pool extends LiveObject {
+class Pool extends LiveTable {
     @Property()
     poolId: string;
 

--- a/Profile/spec.ts
+++ b/Profile/spec.ts
@@ -3,7 +3,7 @@ import {
     BeforeAll,
     BigInt,
     Event,
-    LiveObject,
+    LiveTable,
     OnEvent,
     Property,
     Spec,
@@ -16,7 +16,7 @@ import {
 @Spec({
     uniqueBy: ["profileId", "chainId"],
 })
-class Profile extends LiveObject {
+class Profile extends LiveTable {
     @Property()
     profileId: Address;
 

--- a/Role/spec.ts
+++ b/Role/spec.ts
@@ -1,6 +1,6 @@
 import {
   Event,
-  LiveObject,
+  LiveTable,
   OnEvent,
   Property,
   saveAll,
@@ -15,7 +15,7 @@ import { generatePoolRoleIds } from "../shared/roles.ts";
 @Spec({
   uniqueBy: ["roleId", "chainId"],
 })
-class Role extends LiveObject {
+class Role extends LiveTable {
   @Property()
   roleId: string;
 

--- a/RoleAccount/spec.ts
+++ b/RoleAccount/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll,Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll,Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 /**
  * The accounts associated with an Allo role.
@@ -6,7 +6,7 @@ import { Address, BeforeAll,Event, LiveObject, OnEvent, Property, Spec } from '@
 @Spec({
     uniqueBy: ['roleId', 'accountId', 'chainId']
 })
-class RoleAccount extends LiveObject {
+class RoleAccount extends LiveTable {
 
     @Property()
     roleId: string

--- a/imports.json
+++ b/imports.json
@@ -1,5 +1,5 @@
 {
     "imports": {
-        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.129"
+        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.136"
     }
 }

--- a/shared/decoders.ts
+++ b/shared/decoders.ts
@@ -241,7 +241,7 @@ export function decodeMicroGrantsRegistrationData(
       "uint256",
       "tuple(uint256, string)",
   ])
-  
+
   return {
     registryAnchor: registryAnchor.toLowerCase(),
     recipientAddress: recipientAddress.toLowerCase(),

--- a/strategies/DonationVotingMerkleDistributionStrategy/Base/spec.ts
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Base/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeDonationVotingMerkleDistributionInitializedData } from "../../../shared/decoders.ts";
 
@@ -8,7 +8,7 @@ import { decodeDonationVotingMerkleDistributionInitializedData } from "../../../
 @Spec({
     uniqueBy: ['strategy', 'chainId'],
 })
-class DonationVotingMerkleDistribution extends LiveObject {
+class DonationVotingMerkleDistribution extends LiveTable {
     @Property()
     strategy: Address
 

--- a/strategies/DonationVotingMerkleDistributionStrategy/Payout/spec.ts
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Payout/spec.ts
@@ -3,7 +3,7 @@ import {
     BeforeAll,
     BigInt,
     Event,
-    LiveObject,
+    LiveTable,
     OnEvent,
     Property,
     resolveMetadata,
@@ -19,7 +19,7 @@ import { getStatusFromInt } from "../../../shared/status.ts";
 @Spec({
     uniqueBy: ['strategy', "recipientId", 'chainId']
 })
-class DonationVotingMerkleDistributionPayout extends LiveObject {
+class DonationVotingMerkleDistributionPayout extends LiveTable {
 
     @Property()
     recipientId: Address

--- a/strategies/DonationVotingMerkleDistributionStrategy/Recipient/spec.ts
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Recipient/spec.ts
@@ -2,7 +2,7 @@ import {
     Address,
     BeforeAll,
     Event,
-    LiveObject,
+    LiveTable,
     OnEvent,
     Property,
     saveAll,
@@ -17,7 +17,7 @@ import { getStatusFromInt } from "../../../shared/status.ts";
 @Spec({
     uniqueBy: ["strategy", "recipientId", "chainId"],
 })
-class DonationVotingMerkleDistributionRecipient extends LiveObject {
+class DonationVotingMerkleDistributionRecipient extends LiveTable {
 
     @Property()
     recipientId: Address;

--- a/strategies/MicroGrants/Base/manifest.json
+++ b/strategies/MicroGrants/Base/manifest.json
@@ -1,6 +1,6 @@
 {
     "namespace": "allov2",
-    "name": "MicroGrants",
+    "name": "MicroGrant",
     "version": "0.0.1",
     "displayName": "MicroGrants",
     "description": "index base variables in MicroGrants strategy",

--- a/strategies/MicroGrants/Base/spec.ts
+++ b/strategies/MicroGrants/Base/spec.ts
@@ -68,7 +68,7 @@ class MicroGrants extends LiveTable {
 
         this.poolId = event.data.poolId.toString()
         
-        const strategyId = await this.contract.strategyId().toString()
+        const strategyId = (await this.contract.getStrategyId()).toString()
         this.strategyId = strategyId
     }
 

--- a/strategies/MicroGrants/Base/spec.ts
+++ b/strategies/MicroGrants/Base/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, BigInt, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, BigInt, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeMicroGrantsInitializedData } from "../../../shared/decoders.ts";
 
@@ -8,7 +8,7 @@ import { decodeMicroGrantsInitializedData } from "../../../shared/decoders.ts";
 @Spec({
     uniqueBy: ['strategy', 'chainId']
 })
-class MicroGrants extends LiveObject {
+class MicroGrants extends LiveTable {
 
     @Property()
     strategy: Address

--- a/strategies/MicroGrants/Recipient/manifest.json
+++ b/strategies/MicroGrants/Recipient/manifest.json
@@ -1,6 +1,6 @@
 {
     "namespace": "allov2",
-    "name": "MicroGrants_Recipients",
+    "name": "MicroGrantRecipient",
     "version": "0.0.1",
     "displayName": "MicroGrants Recipients",
     "description": "Index Recipients on MicroGrants",

--- a/strategies/MicroGrants/Recipient/spec.ts
+++ b/strategies/MicroGrants/Recipient/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, BigInt, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, BigInt, Event, LiveTable, OnEvent, Property, Spec, isNullAddress } from '@spec.dev/core'
 
 import { decodeMicroGrantsRegistrationData } from '../../../shared/decoders.ts'
 import { getStatusFromInt } from '../../../shared/status.ts'
@@ -9,7 +9,7 @@ import { getStatusFromInt } from '../../../shared/status.ts'
 @Spec({
     uniqueBy: ['strategy', 'recipientId', 'chainId']
 })
-class MicroGrantsRecipient extends LiveObject {
+class MicroGrantsRecipient extends LiveTable {
     @Property()
     recipientId: Address
 
@@ -67,7 +67,7 @@ class MicroGrantsRecipient extends LiveObject {
         
         this.poolId = poolId.toString()
         this.recipientAddress = recipientAddress
-        this.isUsingRegistryAnchor = registryAnchor == "0x0000000000000000000000000000000000000000"
+        this.isUsingRegistryAnchor = isNullAddress(registryAnchor)
         this.requestedAmount = requestedAmount
         this.metadataProtocol = metadata.protocol
         this.metadataPointer = metadata.pointer

--- a/strategies/QVSimpleStrategy/Base/spec.ts
+++ b/strategies/QVSimpleStrategy/Base/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeQVSimpleInitializedData } from "../../../shared/decoders.ts";
 
@@ -8,7 +8,7 @@ import { decodeQVSimpleInitializedData } from "../../../shared/decoders.ts";
 @Spec({
     uniqueBy: ['strategy', 'chainId'],
 })
-class QVSimple extends LiveObject {
+class QVSimple extends LiveTable {
     @Property()
     strategy: Address
 

--- a/strategies/QVSimpleStrategy/Recipient/spec.ts
+++ b/strategies/QVSimpleStrategy/Recipient/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeGenericRegistrationData } from '../../../shared/decoders.ts'
 import { getStatusFromInt } from '../../../shared/status.ts'
@@ -9,7 +9,7 @@ import { getStatusFromInt } from '../../../shared/status.ts'
 @Spec({
     uniqueBy: ['strategy', 'recipientId', 'chainId']
 })
-class QVSimpleRecipient extends LiveObject {
+class QVSimpleRecipient extends LiveTable {
     @Property()
     recipientId: Address;
 

--- a/strategies/RFPStrategy/Base/spec.ts
+++ b/strategies/RFPStrategy/Base/spec.ts
@@ -59,7 +59,7 @@ class RFP extends LiveTable {
         this.poolId = event.data.poolId.toString()
         this.voteThreshold = 1 // default to 1 for RFP Simple
         
-        const strategyId = await this.contract.strategyId().toString()
+        const strategyId = (await this.contract.getStrategyId()).toString()
         this.strategyId = strategyId
     }
 
@@ -75,7 +75,7 @@ class RFP extends LiveTable {
         this.voteThreshold = voteThreshold
         this.poolId = event.data.poolId.toString()
 
-        const strategyId = await this.contract.strategyId().toString()
+        const strategyId = (await this.contract.getStrategyId()).toString()
         this.strategyId = strategyId
     }
 

--- a/strategies/RFPStrategy/Base/spec.ts
+++ b/strategies/RFPStrategy/Base/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, BigInt, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, BigInt, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeRFPCommitteeInitializedData, decodeRFPSimpleInitializedData } from "../../../shared/decoders.ts";
 
@@ -8,7 +8,7 @@ import { decodeRFPCommitteeInitializedData, decodeRFPSimpleInitializedData } fro
 @Spec({
     uniqueBy: ['strategy', 'chainId']
 })
-class RFP extends LiveObject {
+class RFP extends LiveTable {
 
     @Property()
     strategy: Address

--- a/strategies/RFPStrategy/Milestone/spec.ts
+++ b/strategies/RFPStrategy/Milestone/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, Event, LiveObject, OnEvent, Property, saveAll,Spec } from '@spec.dev/core'
+import { Address, BeforeAll, Event, LiveTable, OnEvent, Property, saveAll,Spec } from '@spec.dev/core'
 
 import { getStatusFromInt } from '../../../shared/status.ts'
 
@@ -8,7 +8,7 @@ import { getStatusFromInt } from '../../../shared/status.ts'
 @Spec({
     uniqueBy: ['strategy', 'milestoneId', 'chainId']
 })
-class RFPMilestone extends LiveObject {
+class RFPMilestone extends LiveTable {
 
     @Property()
     milestoneId: number

--- a/strategies/RFPStrategy/Recipient/spec.ts
+++ b/strategies/RFPStrategy/Recipient/spec.ts
@@ -1,4 +1,4 @@
-import { Address, BeforeAll, BigInt, Event, LiveObject, OnEvent, Property, Spec } from '@spec.dev/core'
+import { Address, BeforeAll, BigInt, Event, LiveTable, OnEvent, Property, Spec } from '@spec.dev/core'
 
 import { decodeRFPRegistrationData } from '../../../shared/decoders.ts'
 import { getStatusFromInt } from '../../../shared/status.ts'
@@ -9,7 +9,7 @@ import { getStatusFromInt } from '../../../shared/status.ts'
 @Spec({
     uniqueBy: ['strategy', 'recipientId', 'chainId']
 })
-class RFPRecipient extends LiveObject {
+class RFPRecipient extends LiveTable {
     @Property()
     recipientId: Address
 


### PR DESCRIPTION
* Deprecate `LiveObject` in favor of `LiveTable`.
* Bump core-lib version to `0.0.136`
* Tweak micro live object names to be singular/without underscores