### PR TITLE
MicroGrant version bumps

### DIFF
--- a/strategies/MicroGrants/Base/manifest.json
+++ b/strategies/MicroGrants/Base/manifest.json
@@ -1,7 +1,7 @@
 {
     "namespace": "allov2",
     "name": "MicroGrant",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "displayName": "MicroGrants",
     "description": "index base variables in MicroGrants strategy",
     "chains": [

--- a/strategies/MicroGrants/Recipient/manifest.json
+++ b/strategies/MicroGrants/Recipient/manifest.json
@@ -1,7 +1,7 @@
 {
     "namespace": "allov2",
     "name": "MicroGrantRecipient",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "displayName": "MicroGrants Recipients",
     "description": "Index Recipients on MicroGrants",
     "chains": [


### PR DESCRIPTION
Bumps versions of `MicroGrant` and `MicroGrantRecipient` to `0.0.2`. This is required because the `uniqueBy` properties were modified on both of these live tables, so the underlying table in the Spec ecosystem needs to reflect this change as well. 