### PR TITLE
Data Source Change for MicroGrant live tables

### DIFF
--- a/.spec/project.toml
+++ b/.spec/project.toml
@@ -22,10 +22,10 @@ id = 'allov2.Allo@0.0.1'
 id = 'goerli.Transaction@0.0.1'
 
 [objects.MicroGrant]
-id = 'allov2.MicroGrant@0.0.1'
+id = 'allov2.MicroGrant@0.0.2'
 
 [objects.MicroGrantRecipient]
-id = 'allov2.MicroGrantRecipient@0.0.1'
+id = 'allov2.MicroGrantRecipient@0.0.2'
 
 [objects.Allocated]
 id = 'goerli.contracts.allov2.MicroGrantsStrategy.Allocated@0xb735720d94de3d169791e2f713cbac8da02eb4d5a344d5a6d5ef542fdf3b2438'


### PR DESCRIPTION
Changes the live tables in your `alloscan` project to use the new `0.0.2` version of the microgrants-related tables from the ecosystem.