### PR TITLE
Codified contract groups

### DIFF
--- a/.spec/migrations/1700161440000_create_allocated/up.sql
+++ b/.spec/migrations/1700161440000_create_allocated/up.sql
@@ -1,6 +1,6 @@
 BEGIN;
     create table public.allocated (recipient_id varchar, status varchar, sender varchar, contract_name varchar, contract_address varchar, transaction_hash varchar, log_index int4, block_hash varchar, block_number int8, block_timestamp timestamptz, chain_id varchar);
-    alter table public.allocated add constraint pk_aj9tf1zqrudmfm6lhjbxex primary key (transaction_hash, log_index);
+    alter table public.allocated add constraint pk_aj9tf1zqrudmfm6lhjbxex primary key (transaction_hash, log_index, chain_id);
     create index idx_wxeewmbofi3ugmxszruupy on public.allocated (block_number, chain_id);
     create index idx_7ddunrdjfzvd9kgawjf51h on public.allocated (block_timestamp);
     COMMENT ON TABLE public.allocated IS E'@foreignKey (contract_address, chain_id) references public.micro_grant (strategy, chain_id)|@fieldName microGrant|@foreignFieldName allocateds';

--- a/.spec/migrations/1700161504000_create_distributed/up.sql
+++ b/.spec/migrations/1700161504000_create_distributed/up.sql
@@ -1,6 +1,6 @@
 BEGIN;
     create table public.distributed (recipient_id varchar, recipient_address varchar, amount varchar, sender varchar, contract_name varchar, contract_address varchar, transaction_hash varchar, log_index int4, block_hash varchar, block_number int8, block_timestamp timestamptz, chain_id varchar);
-    alter table public.distributed add constraint pk_wmjkmyft4jsezeqj5reuq9 primary key (transaction_hash, log_index);
+    alter table public.distributed add constraint pk_wmjkmyft4jsezeqj5reuq9 primary key (transaction_hash, log_index, chain_id);
     create index idx_ipnkl2uh6ak1jmqe3buqxe on public.distributed (block_number, chain_id);
     create index idx_ig1upbfdlsjfchmxhrdhgp on public.distributed (block_timestamp);
     COMMENT ON TABLE public.distributed IS E'@foreignKey (contract_address, chain_id) references public.micro_grant (strategy, chain_id)|@fieldName microGrant|@foreignFieldName distributeds';

--- a/.spec/project.toml
+++ b/.spec/project.toml
@@ -28,10 +28,10 @@ id = 'allov2.MicroGrant@0.0.4'
 id = 'allov2.MicroGrantRecipient@0.0.5'
 
 [objects.Allocated]
-id = 'goerli.contracts.allov2.MicroGrantsCommon.Allocated@0xb735720d94de3d169791e2f713cbac8da02eb4d5a344d5a6d5ef542fdf3b2438'
+id = 'allov2.MicroGrantsCommon.Allocated@0xb735720d94de3d169791e2f713cbac8da02eb4d5a344d5a6d5ef542fdf3b2438'
 
 [objects.Distributed]
-id = 'goerli.contracts.allov2.MicroGrantsCommon.Distributed@0xb5b51454adfa840bd593658325a60a50b0216f12eb5d2937efe6cea935675b7d'
+id = 'allov2.MicroGrantsCommon.Distributed@0xb5b51454adfa840bd593658325a60a50b0216f12eb5d2937efe6cea935675b7d'
 
 # = Live Columns (Outputs) ------------------------------
 
@@ -243,8 +243,8 @@ uniqueBy = [ 'chainId', 'poolId', 'recipientId' ]
 
 [[objects.Allocated.links]]
 table = 'public.allocated'
-uniqueBy = [ 'transactionHash', 'logIndex' ]
+uniqueBy = [ 'transactionHash', 'logIndex', 'chainId' ]
 
 [[objects.Distributed.links]]
 table = 'public.distributed'
-uniqueBy = [ 'transactionHash', 'logIndex' ]
+uniqueBy = [ 'transactionHash', 'logIndex', 'chainId' ]

--- a/Account/manifest.json
+++ b/Account/manifest.json
@@ -3,8 +3,5 @@
     "name": "Account",
     "version": "0.0.1",
     "displayName": "Allo Accounts",
-    "description": "Account which has roles associated with it on allo v2",
-    "chains": [
-        5
-    ]
+    "description": "Account which has roles associated with it on allo v2"
 }

--- a/Allo/manifest.json
+++ b/Allo/manifest.json
@@ -3,8 +3,5 @@
     "name": "Allo",
     "version": "0.0.1",
     "displayName": "Allo",
-    "description": "Global data",
-    "chains": [
-        5
-    ]
+    "description": "Global data"
 }

--- a/Pool/manifest.json
+++ b/Pool/manifest.json
@@ -3,8 +3,5 @@
     "name": "Pool",
     "version": "0.0.5",
     "displayName": "Allo Pools",
-    "description": "All Pools created on Allo",
-    "chains": [
-        5
-    ]
+    "description": "All Pools created on Allo"
 }

--- a/Profile/manifest.json
+++ b/Profile/manifest.json
@@ -3,8 +3,5 @@
     "name": "Profile",
     "version": "0.0.1",
     "displayName": "Allo Profiles",
-    "description": "All Profiles created on Registry",
-    "chains": [
-        5
-    ]
+    "description": "All Profiles created on Registry"
 }

--- a/Role/manifest.json
+++ b/Role/manifest.json
@@ -3,8 +3,5 @@
     "name": "Role",
     "version": "0.0.1",
     "displayName": "Allo Roles",
-    "description": "Role which is used in allo v2 core",
-    "chains": [
-        5
-    ]
+    "description": "Role which is used in allo v2 core"
 }

--- a/RoleAccount/manifest.json
+++ b/RoleAccount/manifest.json
@@ -3,8 +3,5 @@
     "name": "RoleAccount",
     "version": "0.0.1",
     "displayName": "Allo Role -> Account",
-    "description": "Relationship between Role and Account in allo v2",
-    "chains": [
-        5
-    ]
+    "description": "Relationship between Role and Account in allo v2"
 }

--- a/abis/MerkleDistributionStrategy.json
+++ b/abis/MerkleDistributionStrategy.json
@@ -1,0 +1,1155 @@
+[
+    {
+        "inputs": [],
+        "name": "ALLOCATION_ACTIVE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ALLOCATION_NOT_ACTIVE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ALLOCATION_NOT_ENDED",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ALREADY_INITIALIZED",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "AMOUNT_MISMATCH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ANCHOR_ERROR",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ARRAY_MISMATCH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "INVALID",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "INVALID_ADDRESS",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "INVALID_FEE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "INVALID_METADATA",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "INVALID_REGISTRATION",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "IS_APPROVED_STRATEGY",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "MISMATCH",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NONCE_NOT_AVAILABLE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NOT_APPROVED_STRATEGY",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NOT_ENOUGH_FUNDS",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NOT_INITIALIZED",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "NOT_PENDING_OWNER",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "POOL_ACTIVE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "POOL_INACTIVE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RECIPIENT_ALREADY_ACCEPTED",
+        "type": "error"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "RECIPIENT_ERROR",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "RECIPIENT_NOT_ACCEPTED",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "REGISTRATION_NOT_ACTIVE",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "UNAUTHORIZED",
+        "type": "error"
+    },
+    {
+        "inputs": [],
+        "name": "ZERO_ADDRESS",
+        "type": "error"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Allocated",
+        "type": "event",
+        "signature": "0x463ffc2cf8b1596445c417388ed30e53eb67cf6668cb2be7f0addf8a78c8441b"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "BatchPayoutSuccessful",
+        "type": "event",
+        "signature": "0x7ec3272052827f7b50d9e84f98172cbb80c112df1e377c5b97ea77f1812db8d9"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "recipientAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Distributed",
+        "type": "event",
+        "signature": "0xb5b51454adfa840bd593658325a60a50b0216f12eb5d2937efe6cea935675b7d"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "protocol",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "pointer",
+                        "type": "string"
+                    }
+                ],
+                "indexed": false,
+                "internalType": "struct Metadata",
+                "name": "metadata",
+                "type": "tuple"
+            }
+        ],
+        "name": "DistributionUpdated",
+        "type": "event",
+        "signature": "0xdc7180ca4affc84269428ed20ef950e745126f11691b010c4a7d49458421008f"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "grantee",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "FundsDistributed",
+        "type": "event",
+        "signature": "0xa6b66f665010d2f7435f110111aaa34b56564074f66081bef606d996fc8caa6f"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "allo",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes32",
+                "name": "profileId",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "poolId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event",
+        "signature": "0xef1e1837ec90bc3e923731135520d55610d83e2facf0f45963412f5b29ecacf4"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "active",
+                "type": "bool"
+            }
+        ],
+        "name": "PoolActive",
+        "type": "event",
+        "signature": "0xd94c9bc4d43c51d8dc345a016d8e3d994432fac68e72832e4cf3a616bd8efae0"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "rowIndex",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "fullRow",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "RecipientStatusUpdated",
+        "type": "event",
+        "signature": "0x941884a9a55191a7401466aaf8a0d2b7c8b082055a5a2b345b83c73940172ac4"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Registered",
+        "type": "event",
+        "signature": "0xa197306e3dd5494a61a695381aa809a53b8e377a685e84e404a85d5a8da6cc62"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "registrationStartTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "registrationEndTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "allocationStartTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "allocationEndTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "TimestampsUpdated",
+        "type": "event",
+        "signature": "0xcb0fb7a7b87db2f472ee8977444cfdbc51993ce660aca27a5969a724fae6dcf3"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint8",
+                "name": "status",
+                "type": "uint8"
+            }
+        ],
+        "name": "UpdatedRegistration",
+        "type": "event",
+        "signature": "0xcec1da3f7f0b8a344dd1025d06e2ddd48b14880395997ad97cbdb439acc761d4"
+    },
+    {
+        "inputs": [],
+        "name": "NATIVE",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xa0cf0aea"
+    },
+    {
+        "inputs": [],
+        "name": "PERMIT2",
+        "outputs": [
+            {
+                "internalType": "contract ISignatureTransfer",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x6afdd850"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "allocate",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+        "signature": "0xef2920fc"
+    },
+    {
+        "inputs": [],
+        "name": "allocationEndTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4533d678"
+    },
+    {
+        "inputs": [],
+        "name": "allocationStartTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xd2e17f59"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "allowedTokens",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xe744092e"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_recipientIds",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "distribute",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x0a6f0ee9"
+    },
+    {
+        "inputs": [],
+        "name": "distributionMetadata",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "protocol",
+                "type": "uint256"
+            },
+            {
+                "internalType": "string",
+                "name": "pointer",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x59a3977b"
+    },
+    {
+        "inputs": [],
+        "name": "distributionStarted",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x21755088"
+    },
+    {
+        "inputs": [],
+        "name": "getAllo",
+        "outputs": [
+            {
+                "internalType": "contract IAllo",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x15cc481e"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_recipientIds",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "_data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "getPayouts",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipientAddress",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct IStrategy.PayoutSummary[]",
+                "name": "",
+                "type": "tuple[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xb2b878d0"
+    },
+    {
+        "inputs": [],
+        "name": "getPoolAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4ab4ba42"
+    },
+    {
+        "inputs": [],
+        "name": "getPoolId",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x38fff2d0"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "getRecipient",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bool",
+                        "name": "useRegistryAnchor",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "recipientAddress",
+                        "type": "address"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "uint256",
+                                "name": "protocol",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "string",
+                                "name": "pointer",
+                                "type": "string"
+                            }
+                        ],
+                        "internalType": "struct Metadata",
+                        "name": "metadata",
+                        "type": "tuple"
+                    }
+                ],
+                "internalType": "struct DonationVotingMerkleDistributionBaseStrategy.Recipient",
+                "name": "recipient",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x62812a39"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "getRecipientStatus",
+        "outputs": [
+            {
+                "internalType": "enum IStrategy.Status",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xeb11af93"
+    },
+    {
+        "inputs": [],
+        "name": "getStrategyId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x42fda9c7"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_index",
+                "type": "uint256"
+            }
+        ],
+        "name": "hasBeenDistributed",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x5f1b55f3"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "increasePoolAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xf5b0dfb7"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_poolId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xedd146cc"
+    },
+    {
+        "inputs": [],
+        "name": "isDistributionSet",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x2d52eff2"
+    },
+    {
+        "inputs": [],
+        "name": "isPoolActive",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xdf868ed3"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_allocator",
+                "type": "address"
+            }
+        ],
+        "name": "isValidAllocator",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4d31d087"
+    },
+    {
+        "inputs": [],
+        "name": "merkleRoot",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x2eb4a7ab"
+    },
+    {
+        "inputs": [],
+        "name": "metadataRequired",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xcb0e85a6"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes[]",
+                "name": "data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "multicall",
+        "outputs": [
+            {
+                "internalType": "bytes[]",
+                "name": "results",
+                "type": "bytes[]"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xac9650d8"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "recipientToStatusIndexes",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x01fc1c64"
+    },
+    {
+        "inputs": [],
+        "name": "recipientsCounter",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x95355b3b"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "registerRecipient",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+        "signature": "0x2bbe0cae"
+    },
+    {
+        "inputs": [],
+        "name": "registrationEndTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xdff7d2c7"
+    },
+    {
+        "inputs": [],
+        "name": "registrationStartTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x9af5c09d"
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "index",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "statusRow",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct DonationVotingMerkleDistributionBaseStrategy.ApplicationStatus[]",
+                "name": "statuses",
+                "type": "tuple[]"
+            }
+        ],
+        "name": "reviewRecipients",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x465831cd"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "name": "statusesBitMap",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xf6f25891"
+    },
+    {
+        "inputs": [],
+        "name": "totalPayoutAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xe7efcfc2"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes32",
+                "name": "_merkleRoot",
+                "type": "bytes32"
+            },
+            {
+                "components": [
+                    {
+                        "internalType": "uint256",
+                        "name": "protocol",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "string",
+                        "name": "pointer",
+                        "type": "string"
+                    }
+                ],
+                "internalType": "struct Metadata",
+                "name": "_distributionMetadata",
+                "type": "tuple"
+            }
+        ],
+        "name": "updateDistribution",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x73af3453"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint64",
+                "name": "_registrationStartTime",
+                "type": "uint64"
+            },
+            {
+                "internalType": "uint64",
+                "name": "_registrationEndTime",
+                "type": "uint64"
+            },
+            {
+                "internalType": "uint64",
+                "name": "_allocationStartTime",
+                "type": "uint64"
+            },
+            {
+                "internalType": "uint64",
+                "name": "_allocationEndTime",
+                "type": "uint64"
+            }
+        ],
+        "name": "updatePoolTimestamps",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x2143e92f"
+    },
+    {
+        "inputs": [],
+        "name": "useRegistryAnchor",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x57089739"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x2e1a7d4d"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    }
+]

--- a/abis/MicroGrantsCommon.json
+++ b/abis/MicroGrantsCommon.json
@@ -1,0 +1,839 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_allo",
+                "type": "address"
+            },
+            {
+                "internalType": "string",
+                "name": "_name",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor",
+        "signature": "0x5bc6238b"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "enum IStrategy.Status",
+                "name": "status",
+                "type": "uint8"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Allocated",
+        "type": "event",
+        "signature": "0xb735720d94de3d169791e2f713cbac8da02eb4d5a344d5a6d5ef542fdf3b2438"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Allocated",
+        "type": "event",
+        "signature": "0x463ffc2cf8b1596445c417388ed30e53eb67cf6668cb2be7f0addf8a78c8441b"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "allocator",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "bool",
+                "name": "_flag",
+                "type": "bool"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "AllocatorSet",
+        "type": "event",
+        "signature": "0xb50515ac68c6752ce8d118ee9c125360859a03dcb13a0cfb6b3faad68217f4bd"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "approvalThreshold",
+                "type": "uint256"
+            }
+        ],
+        "name": "ApprovalThresholdUpdated",
+        "type": "event",
+        "signature": "0x3105a3dc553e12034caac9827a83c245fe17eef4ee1eedb45238ac7449a5bbec"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "recipientAddress",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "amount",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Distributed",
+        "type": "event",
+        "signature": "0xb5b51454adfa840bd593658325a60a50b0216f12eb5d2937efe6cea935675b7d"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "poolId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "Initialized",
+        "type": "event",
+        "signature": "0x91efa3d50feccde0d0d202f8ae5c41ca0b2be614cebcb2bd2f4b019396e6568a"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "maxRequestedAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "MaxRequestedAmountIncreased",
+        "type": "event",
+        "signature": "0xbcd4e1b1c11d47ad4c6c51ad73d8e77d29313bc1a491330186316a74a1f995f4"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "bool",
+                "name": "active",
+                "type": "bool"
+            }
+        ],
+        "name": "PoolActive",
+        "type": "event",
+        "signature": "0xd94c9bc4d43c51d8dc345a016d8e3d994432fac68e72832e4cf3a616bd8efae0"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "Registered",
+        "type": "event",
+        "signature": "0xa197306e3dd5494a61a695381aa809a53b8e377a685e84e404a85d5a8da6cc62"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "allocationStartTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint64",
+                "name": "allocationEndTime",
+                "type": "uint64"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "TimestampsUpdated",
+        "type": "event",
+        "signature": "0x70d34c8836b996cffd8970ba5edf940d83ca7c8f30f738ea4fd8566a37d93359"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            },
+            {
+                "indexed": false,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address"
+            }
+        ],
+        "name": "UpdatedRegistration",
+        "type": "event",
+        "signature": "0xaf5977db3aa7e6fc7d05e21c791ebd214afa76da27c8d8ddc8e4a9f742d7b236"
+    },
+    {
+        "inputs": [],
+        "name": "NATIVE",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xa0cf0aea"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "allocate",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+        "signature": "0xef2920fc"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "allocated",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x2b302cbd"
+    },
+    {
+        "inputs": [],
+        "name": "allocationEndTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4533d678"
+    },
+    {
+        "inputs": [],
+        "name": "allocationStartTime",
+        "outputs": [
+            {
+                "internalType": "uint64",
+                "name": "",
+                "type": "uint64"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xd2e17f59"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "allocators",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x084ea36e"
+    },
+    {
+        "inputs": [],
+        "name": "approvalThreshold",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x7d0eef61"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_allocators",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bool[]",
+                "name": "_flags",
+                "type": "bool[]"
+            }
+        ],
+        "name": "batchSetAllocator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xa15acfd5"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_recipientIds",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "distribute",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x0a6f0ee9"
+    },
+    {
+        "inputs": [],
+        "name": "getAllo",
+        "outputs": [
+            {
+                "internalType": "contract IAllo",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x15cc481e"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address[]",
+                "name": "_recipientIds",
+                "type": "address[]"
+            },
+            {
+                "internalType": "bytes[]",
+                "name": "_data",
+                "type": "bytes[]"
+            }
+        ],
+        "name": "getPayouts",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "address",
+                        "name": "recipientAddress",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount",
+                        "type": "uint256"
+                    }
+                ],
+                "internalType": "struct IStrategy.PayoutSummary[]",
+                "name": "",
+                "type": "tuple[]"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xb2b878d0"
+    },
+    {
+        "inputs": [],
+        "name": "getPoolAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4ab4ba42"
+    },
+    {
+        "inputs": [],
+        "name": "getPoolId",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x38fff2d0"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "getRecipient",
+        "outputs": [
+            {
+                "components": [
+                    {
+                        "internalType": "bool",
+                        "name": "useRegistryAnchor",
+                        "type": "bool"
+                    },
+                    {
+                        "internalType": "address",
+                        "name": "recipientAddress",
+                        "type": "address"
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "requestedAmount",
+                        "type": "uint256"
+                    },
+                    {
+                        "internalType": "enum IStrategy.Status",
+                        "name": "recipientStatus",
+                        "type": "uint8"
+                    },
+                    {
+                        "components": [
+                            {
+                                "internalType": "uint256",
+                                "name": "protocol",
+                                "type": "uint256"
+                            },
+                            {
+                                "internalType": "string",
+                                "name": "pointer",
+                                "type": "string"
+                            }
+                        ],
+                        "internalType": "struct Metadata",
+                        "name": "metadata",
+                        "type": "tuple"
+                    }
+                ],
+                "internalType": "struct MicroGrantsStrategy.Recipient",
+                "name": "",
+                "type": "tuple"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x62812a39"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_recipientId",
+                "type": "address"
+            }
+        ],
+        "name": "getRecipientStatus",
+        "outputs": [
+            {
+                "internalType": "enum IStrategy.Status",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xeb11af93"
+    },
+    {
+        "inputs": [],
+        "name": "getStrategyId",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x42fda9c7"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_maxRequestedAmount",
+                "type": "uint256"
+            }
+        ],
+        "name": "increaseMaxRequestedAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xbfa80731"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_amount",
+                "type": "uint256"
+            }
+        ],
+        "name": "increasePoolAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xf5b0dfb7"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_poolId",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            }
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xedd146cc"
+    },
+    {
+        "inputs": [],
+        "name": "isPoolActive",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xdf868ed3"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_allocator",
+                "type": "address"
+            }
+        ],
+        "name": "isValidAllocator",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x4d31d087"
+    },
+    {
+        "inputs": [],
+        "name": "maxRequestedAmount",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0xba539f8f"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            },
+            {
+                "internalType": "enum IStrategy.Status",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "name": "recipientAllocations",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x6f46ffb9"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "bytes",
+                "name": "_data",
+                "type": "bytes"
+            },
+            {
+                "internalType": "address",
+                "name": "_sender",
+                "type": "address"
+            }
+        ],
+        "name": "registerRecipient",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "recipientId",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+        "signature": "0x2bbe0cae"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_allocator",
+                "type": "address"
+            },
+            {
+                "internalType": "bool",
+                "name": "_flag",
+                "type": "bool"
+            }
+        ],
+        "name": "setAllocator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x80faddeb"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_approvalThreshold",
+                "type": "uint256"
+            }
+        ],
+        "name": "setApprovalThreshold",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0xa0016b8c"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint64",
+                "name": "_allocationStartTime",
+                "type": "uint64"
+            },
+            {
+                "internalType": "uint64",
+                "name": "_allocationEndTime",
+                "type": "uint64"
+            }
+        ],
+        "name": "updatePoolTimestamps",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x75777aaa"
+    },
+    {
+        "inputs": [],
+        "name": "useRegistryAnchor",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function",
+        "signature": "0x57089739"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_token",
+                "type": "address"
+            }
+        ],
+        "name": "withdraw",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "signature": "0x51cff8d9"
+    }
+]

--- a/contracts.spec.json
+++ b/contracts.spec.json
@@ -1,0 +1,63 @@
+{
+  "namespace": "allov2",
+  "groups": [
+    {
+      "name": "Registry",
+      "contracts": [
+        {
+          "chainId": 5,
+          "address": "0x4aacca72145e1df2aec137e1f3c5e3d75db8b5f3"
+        }
+      ]
+    },
+    {
+      "name": "Allo",
+      "contracts": [
+        {
+          "chainId": 5,
+          "address": "0x1133ea7af70876e64665ecd07c0a0476d09465a1"
+        }
+      ]
+    },
+    {
+      "name": "MicroGrantsCommon",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "MicroGrantsStrategy",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "MicroGrantsGovStrategy",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "MicroGrantsHatsStrategy",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "QVSimpleStrategy",
+      "isFactoryGroup": true
+    },    
+    {
+      "name": "RFPSimpleStrategy",
+      "isFactoryGroup": true
+    },    
+    {
+      "name": "RFPCommitteeStrategy",
+      "isFactoryGroup": true
+    }, 
+    {
+      "name": "DonationVotingMerkleDistributionVaultStrategy",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "DonationVotingMerkleDistributionDirectTransferStrategy",
+      "isFactoryGroup": true
+    },
+    {
+      "name": "MerkleDistributionStrategy",
+      "isFactoryGroup": true
+    }
+  ]
+}

--- a/imports.json
+++ b/imports.json
@@ -1,5 +1,5 @@
 {
     "imports": {
-        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.136"
+        "@spec.dev/core": "https://esm.sh/@spec.dev/core@0.0.140"
     }
 }

--- a/strategies/DonationVotingMerkleDistributionStrategy/Base/manifest.json
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Base/manifest.json
@@ -3,8 +3,5 @@
     "name": "DonationVotingMerkleDistribution",
     "version": "0.0.1",
     "displayName": "DonationVotingMerkleDistribution",
-    "description": "index base variables in DonationVotingMerkleDistribution strategy",
-    "chains": [
-        5
-    ]
+    "description": "index base variables in DonationVotingMerkleDistribution strategy"
 }

--- a/strategies/DonationVotingMerkleDistributionStrategy/Payout/manifest.json
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Payout/manifest.json
@@ -1,10 +1,7 @@
 {
     "namespace": "allov2",
-    "name": "DonationVotingMerkleDistribution_Payout",
+    "name": "DonationVotingMerkleDistributionPayout",
     "version": "0.0.1",
     "displayName": "DonationVotingMerkleDistribution Payout",
-    "description": "Index all payouts based on the merkle root",
-    "chains": [
-        5
-    ]
+    "description": "Index all payouts based on the merkle root"
 }

--- a/strategies/DonationVotingMerkleDistributionStrategy/Payout/spec.ts
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Payout/spec.ts
@@ -65,7 +65,7 @@ class DonationVotingMerkleDistributionPayout extends LiveTable {
     @OnEvent('allov2.DonationVotingMerkleDistributionVaultStrategy.DistributionUpdated', { autoSave: false })
     async onDistributionUpdated(event: Event) {
 
-        const [protocol, pointer] = event.data.distributionMetadata
+        const [protocolId, pointer] = event.data.distributionMetadata
 
         await this._softDeleteExistingPayouts()
 
@@ -74,7 +74,7 @@ class DonationVotingMerkleDistributionPayout extends LiveTable {
 
         const poolId = await this.contract.getPoolId()
 
-        const payoutsMetadata = await resolveMetadata(pointer, { protocol })
+        const payoutsMetadata = await resolveMetadata(pointer, { protocolId })
         for (let i = 0; i <= payoutsMetadata.length; i++) {
             // create new payout record
             const payout = this.new(DonationVotingMerkleDistributionPayout, {

--- a/strategies/DonationVotingMerkleDistributionStrategy/Recipient/manifest.json
+++ b/strategies/DonationVotingMerkleDistributionStrategy/Recipient/manifest.json
@@ -1,10 +1,7 @@
 {
     "namespace": "allov2",
-    "name": "DonationVotingMerkleDistribution_Recipient",
+    "name": "DonationVotingMerkleDistributionRecipient",
     "version": "0.0.1",
     "displayName": "DonationVotingMerkleDistribution Recipient",
-    "description": "Index Recipients on DonationVotingMerkleDistribution strategy",
-    "chains": [
-        5
-    ]
+    "description": "Index Recipients on DonationVotingMerkleDistribution strategy"
 }

--- a/strategies/MicroGrants/Base/manifest.json
+++ b/strategies/MicroGrants/Base/manifest.json
@@ -3,8 +3,5 @@
     "name": "MicroGrant",
     "version": "0.0.4",
     "displayName": "MicroGrants",
-    "description": "index base variables in MicroGrants strategy",
-    "chains": [
-        5
-    ]
+    "description": "index base variables in MicroGrants strategy"
 }

--- a/strategies/MicroGrants/Recipient/manifest.json
+++ b/strategies/MicroGrants/Recipient/manifest.json
@@ -3,8 +3,5 @@
     "name": "MicroGrantRecipient",
     "version": "0.0.5",
     "displayName": "MicroGrants Recipients",
-    "description": "Index Recipients on MicroGrants",
-    "chains": [
-        5
-    ]
+    "description": "Index Recipients on MicroGrants"
 }

--- a/strategies/QVSimpleStrategy/Base/manifest.json
+++ b/strategies/QVSimpleStrategy/Base/manifest.json
@@ -3,8 +3,5 @@
     "name": "QVSimple",
     "version": "0.0.1",
     "displayName": "QVSimple",
-    "description": "Index base variables in QVSimple strategy",
-    "chains": [
-        5
-    ]
+    "description": "Index base variables in QVSimple strategy"
 }

--- a/strategies/QVSimpleStrategy/Recipient/manifest.json
+++ b/strategies/QVSimpleStrategy/Recipient/manifest.json
@@ -1,10 +1,7 @@
 {
     "namespace": "allov2",
-    "name": "QVSimple_Recipient",
+    "name": "QVSimpleRecipient",
     "version": "0.0.1",
     "displayName": "QVSimple Recipient",
-    "description": "Index Recipients on QVSimple strategy",
-    "chains": [
-        5
-    ]
+    "description": "Index Recipients on QVSimple strategy"
 }

--- a/strategies/RFPStrategy/Base/manifest.json
+++ b/strategies/RFPStrategy/Base/manifest.json
@@ -3,8 +3,5 @@
     "name": "RFP",
     "version": "0.0.1",
     "displayName": "RFP",
-    "description": "index base variable in RFPSimple",
-    "chains": [
-        5
-    ]
+    "description": "index base variable in RFPSimple"
 }

--- a/strategies/RFPStrategy/Milestone/manifest.json
+++ b/strategies/RFPStrategy/Milestone/manifest.json
@@ -1,10 +1,7 @@
 {
     "namespace": "allov2",
-    "name": "RFP_Milestone",
+    "name": "RFPMilestone",
     "version": "0.0.1",
     "displayName": "RFP Milestone",
-    "description": "Index Milestones on RFPSimple & RFPCommitee",
-    "chains": [
-        5
-    ]
+    "description": "Index Milestones on RFPSimple & RFPCommitee"
 }

--- a/strategies/RFPStrategy/Recipient/manifest.json
+++ b/strategies/RFPStrategy/Recipient/manifest.json
@@ -1,10 +1,7 @@
 {
     "namespace": "allov2",
-    "name": "RFP_Registration",
+    "name": "RFPRegistration",
     "version": "0.0.1",
     "displayName": "RFP Registration",
-    "description": "Index Registation on RFPSimple",
-    "chains": [
-        5
-    ]
+    "description": "Index Registation on RFPSimple"
 }


### PR DESCRIPTION
This PR...

* Codifies all contract groups into `contracts.spec.json`, which is used in conjunction with a new `spec sync contracts` command (requires CLI upgrade)
* Bumps version of the Spec core library to `0.0.140`
* Removes need to specify any `chains` within live table metadata
* Hard migrates event tables to their new chain agnostic data source from the ecosystem

